### PR TITLE
Make CI pass on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,12 +11,21 @@ jobs:
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v2
-      - name: Run brew test-bot
-        run: |
-          set -e
-          brew update
-          HOMEBREW_TAP_DIR="/usr/local/Homebrew/Library/Taps/dxw/homebrew-tap"
-          mkdir -p "$HOMEBREW_TAP_DIR"
-          rm -rf "$HOMEBREW_TAP_DIR"
-          ln -s "$PWD" "$HOMEBREW_TAP_DIR"
-          brew test-bot
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Cache Homebrew Bundler RubyGems
+        id: cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+      - name: Install Homebrew Bundler RubyGems
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: brew install-bundler-gems
+      - run: brew test-bot --only-cleanup-before
+      - run: brew test-bot --only-setup
+      - run: brew test-bot --only-tap-syntax
+      - run: brew test-bot --only-formulae
+        if: github.event_name == 'pull_request'


### PR DESCRIPTION
Before: CI would pass on PR branches, but then fail after merge. It looks like this is because the test-bot formulae steps should only be run on a PR as they rely on HEAD of the branch running the test being different to `main`'s current commit. If the formulae steps are run on `main` itself, they fail with "Error: Invalid usage: Did not find any formulae or commits to test!".

Now: the CI is modelled after homebrew's example workflow: https://github.com/Homebrew/brew/blob/dc09aa6d0ca3c89dab2a4d8cb6274d6d77e063e7/Library/Homebrew/dev-cmd/tap-new.rb#L48-L85. This includes only running the formulae steps on a PR event, by breaking the brew test-bot commands out into specific steps.

Resolves #4.

I'm not 100% sure this will work (and I'm not sure how to test it without merging), but it seems a reasonable theory of what's happening!