### PR TITLE
Fully scope system calls in formulae

### DIFF
--- a/Formula/whippet.rb
+++ b/Formula/whippet.rb
@@ -24,7 +24,7 @@ class Whippet < Formula
   end
 
   test do
-    system "whippet", "generate", "app", "-d /tmp/test-app"
-    system "whippet", "generate", "theme", "-d /tmp/test-app/wp-content/themes/test-theme"
+    system "#{bin}/whippet", "generate", "app", "-d /tmp/test-app"
+    system "#{bin}/whippet", "generate", "theme", "-d /tmp/test-app/wp-content/themes/test-theme"
   end
 end


### PR DESCRIPTION
This PR fixes the error seen [in this action log](https://github.com/dxw/homebrew-tap/actions/runs/4294955803/jobs/7484702648), which was:

```shell
Run brew test-bot --only-tap-syntax
==> Using Homebrew/homebrew-test-bot e[4](https://github.com/dxw/homebrew-tap/actions/runs/4294955803/jobs/7484702648#step:8:5)620c7 (Merge pull request #877 from Homebrew/dependabot/bundler/concurrent-ruby-1.2.2)
==> Using Homebrew/brew 4.0.4-86-g7c1[5](https://github.com/dxw/homebrew-tap/actions/runs/4294955803/jobs/7484702648#step:8:6)dce28 (Merge pull request #14798 from MikeMcQuaid/deprecate_shell)
==> Using Homebrew/homebrew-core 5955e[6](https://github.com/dxw/homebrew-tap/actions/runs/4294955803/jobs/7484702648#step:8:7)f39d1 (logtalk: update 3.63.0 bottle.)
==> Testing dxw/homebrew-tap 66cdc69 (Merge pull request #19 from dxw/dependabot/github_actions/actions/checkout-3.3.0):

==> Running TapSyntax#run!
==> brew style dxw/tap
==> brew readall --aliases dxw/tap
==> brew audit --tap=dxw/tap
==> FAILED
Full audit --tap=dxw/tap output
Error: 1 failed step!
brew audit --tap=dxw/tap
Error: Process completed with exit code 1.
```