### PR TITLE
Use tags for GitHub refs in formulae

### DIFF
--- a/Formula/whippet.rb
+++ b/Formula/whippet.rb
@@ -1,7 +1,7 @@
 class Whippet < Formula
   desc "Framework for building WordPress sites"
   homepage "https://github.com/dxw/whippet"
-  url "https://github.com/dxw/whippet/archive/v2.3.0.tar.gz"
+  url "https://github.com/dxw/whippet/archive/refs/tags/v2.3.0.tar.gz"
   sha256 "d2db07202ba8501cf8e026791601e7f70957d0a86aa14d56390e4a9c23e68102"
 
   depends_on "composer" => :build


### PR DESCRIPTION
Currently the pipeline for this repo fails on `main`: https://github.com/dxw/homebrew-tap/actions/runs/6811758338

### Testing

If the pipeline runs green here, this should be good to merge.